### PR TITLE
ENG-941

### DIFF
--- a/vars/notifyPipelineEnd.groovy
+++ b/vars/notifyPipelineEnd.groovy
@@ -14,7 +14,5 @@ def call(params) {
     request.result = params.result ? params.result : 'success'
 
     def requestBody = JsonOutput.toJson(request)
-    GroovyShell shell = new GroovyShell()
-    def req = shell.parse(new File('sendRequest.groovy'))
-    req.sendRequest(requestBody)
+    sendRequest(requestBody)
 }

--- a/vars/notifyPipelineEnd.groovy
+++ b/vars/notifyPipelineEnd.groovy
@@ -21,7 +21,6 @@ def call(params) {
     post.setDoOutput(true);
     post.setConnectTimeout(5000);
     post.setReadTimeout(5000);
-    println('Read timeout: ' + post.getReadTimeout() + ', connect timeout: ' + post.getConnectTimeout());
     post.setRequestProperty("Content-Type", "application/json");
 
     try {

--- a/vars/notifyPipelineEnd.groovy
+++ b/vars/notifyPipelineEnd.groovy
@@ -16,6 +16,21 @@ def call(params) {
     def requestBody = JsonOutput.toJson(request)
     def url = 'http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status';
 
-    def response = httpRequest acceptType: 'APPLICATION_JSON', contentType: 'APPLICATION_JSON', httpMode: 'POST', requestBody: requestBody, url: url
-    println('Response: (' + response.status + ') ' + response.content)
+    def post = new URL('http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status').openConnection();
+    post.setRequestMethod('POST');
+    post.setDoOutput(true);
+    post.setConnectTimeout(5000);
+    post.setReadTimeout(5000);
+    println('Read timeout: ' + post.getReadTimeout() + ', connect timeout: ' + post.getConnectTimeout());
+    post.setRequestProperty("Content-Type", "application/json");
+
+    try {
+      post.getOutputStream().write(requestBody.getBytes("UTF-8"));
+      def postRC = post.getResponseCode();
+      if(postRC.equals(200)) {
+          println('Response: (' + postRC + ') ' + post.getInputStream().getText());
+      }
+    } catch(Exception ex) {
+      println('Error sending request to endpoint: ' + ex);
+    }
 }

--- a/vars/notifyPipelineEnd.groovy
+++ b/vars/notifyPipelineEnd.groovy
@@ -14,22 +14,7 @@ def call(params) {
     request.result = params.result ? params.result : 'success'
 
     def requestBody = JsonOutput.toJson(request)
-    def url = 'http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status';
-
-    def post = new URL('http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status').openConnection();
-    post.setRequestMethod('POST');
-    post.setDoOutput(true);
-    post.setConnectTimeout(5000);
-    post.setReadTimeout(5000);
-    post.setRequestProperty("Content-Type", "application/json");
-
-    try {
-      post.getOutputStream().write(requestBody.getBytes("UTF-8"));
-      def postRC = post.getResponseCode();
-      if(postRC.equals(200)) {
-          println('Response: (' + postRC + ') ' + post.getInputStream().getText());
-      }
-    } catch(Exception ex) {
-      println('Error sending request to endpoint: ' + ex);
-    }
+    GroovyShell shell = new GroovyShell()
+    def req = shell.parse(new File('sendRequest.groovy'))
+    req.sendRequest(requestBody)
 }

--- a/vars/notifyPipelineStart.groovy
+++ b/vars/notifyPipelineStart.groovy
@@ -21,7 +21,9 @@ def call(params) {
     request.stageNames = getStageNames(pipeline)
 
     def requestBody = JsonOutput.toJson(request)
+    println('before requestBody here...');
     sendRequest(requestBody)
+    println('after requestBody here...');
 }
 
 def getStageNames(pipeline){

--- a/vars/notifyPipelineStart.groovy
+++ b/vars/notifyPipelineStart.groovy
@@ -23,8 +23,19 @@ def call(params) {
     def requestBody = JsonOutput.toJson(request)
     def url = 'http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status';
 
-    def response = httpRequest acceptType: 'APPLICATION_JSON', contentType: 'APPLICATION_JSON', httpMode: 'POST', requestBody: requestBody, url: url
-    println('Response: (' + response.status + ') ' + response.content)
+    // def response = httpRequest acceptType: 'APPLICATION_JSON', contentType: 'APPLICATION_JSON', httpMode: 'POST', requestBody: requestBody, url: url
+
+    def post = new URL('http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status').openConnection();
+    post.setRequestMethod("POST")
+    post.setDoOutput(true)
+    post.setConnectTimeout(5000)
+    post.setRequestProperty("Content-Type", "application/json")
+    post.getOutputStream().write(requestBody.getBytes("UTF-8"));
+    def postRC = post.getResponseCode();
+    println(postRC);
+    if(postRC.equals(200)) {
+        println('Response: (' + postRC + ') ' + post.getInputStream().getText());
+    }
 }
 
 def getStageNames(pipeline){

--- a/vars/notifyPipelineStart.groovy
+++ b/vars/notifyPipelineStart.groovy
@@ -1,4 +1,6 @@
 import groovy.json.JsonOutput
+import java.net.HttpURLConnection;
+import java.net.URL;
 
 def call(params) {
 
@@ -26,10 +28,12 @@ def call(params) {
     // def response = httpRequest acceptType: 'APPLICATION_JSON', contentType: 'APPLICATION_JSON', httpMode: 'POST', requestBody: requestBody, url: url
 
     def post = new URL('http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status').openConnection();
-    post.setRequestMethod("POST")
-    post.setDoOutput(true)
-    post.setConnectTimeout(5000)
-    post.setRequestProperty("Content-Type", "application/json")
+    post.setRequestMethod('POST');
+    post.setDoOutput(true);
+    // post.setConnectTimeout(5000);
+    post.readTimeout(5000);
+    println('Read timeout: ' + post.getReadTimeout() + ', connect timeout: ' + post.getConnectTimeout());
+    post.setRequestProperty("Content-Type", "application/json");
     post.getOutputStream().write(requestBody.getBytes("UTF-8"));
     def postRC = post.getResponseCode();
     println(postRC);

--- a/vars/notifyPipelineStart.groovy
+++ b/vars/notifyPipelineStart.groovy
@@ -31,7 +31,7 @@ def call(params) {
     post.setRequestMethod('POST');
     post.setDoOutput(true);
     // post.setConnectTimeout(5000);
-    post.readTimeout(5000);
+    post.setReadTimeout(5000);
     println('Read timeout: ' + post.getReadTimeout() + ', connect timeout: ' + post.getConnectTimeout());
     post.setRequestProperty("Content-Type", "application/json");
     post.getOutputStream().write(requestBody.getBytes("UTF-8"));

--- a/vars/notifyPipelineStart.groovy
+++ b/vars/notifyPipelineStart.groovy
@@ -21,24 +21,9 @@ def call(params) {
     request.stageNames = getStageNames(pipeline)
 
     def requestBody = JsonOutput.toJson(request)
-    def url = 'http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status';
-
-    def post = new URL('http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status').openConnection();
-    post.setRequestMethod('POST');
-    post.setDoOutput(true);
-    post.setConnectTimeout(5000);
-    post.setReadTimeout(5000);
-    post.setRequestProperty("Content-Type", "application/json");
-
-    try {
-      post.getOutputStream().write(requestBody.getBytes("UTF-8"));
-      def postRC = post.getResponseCode();
-      if(postRC.equals(200)) {
-          println('Response: (' + postRC + ') ' + post.getInputStream().getText());
-      }
-    } catch(Exception ex) {
-      println('Error sending request to endpoint: ' + ex);
-    }
+    GroovyShell shell = new GroovyShell()
+    def req = shell.parse(new File('sendRequest.groovy'))
+    req.sendRequest(requestBody)
 }
 
 def getStageNames(pipeline){

--- a/vars/notifyPipelineStart.groovy
+++ b/vars/notifyPipelineStart.groovy
@@ -30,13 +30,11 @@ def call(params) {
     post.setDoOutput(true);
     post.setConnectTimeout(5000);
     post.setReadTimeout(5000);
-    println('Read timeout: ' + post.getReadTimeout() + ', connect timeout: ' + post.getConnectTimeout());
     post.setRequestProperty("Content-Type", "application/json");
 
     try {
       post.getOutputStream().write(requestBody.getBytes("UTF-8"));
       def postRC = post.getResponseCode();
-      // println(postRC);
       if(postRC.equals(200)) {
           println('Response: (' + postRC + ') ' + post.getInputStream().getText());
       }

--- a/vars/notifyPipelineStart.groovy
+++ b/vars/notifyPipelineStart.groovy
@@ -32,7 +32,13 @@ def call(params) {
     post.setReadTimeout(5000);
     println('Read timeout: ' + post.getReadTimeout() + ', connect timeout: ' + post.getConnectTimeout());
     post.setRequestProperty("Content-Type", "application/json");
-    post.getOutputStream().write(requestBody.getBytes("UTF-8"));
+
+    try {
+      post.getOutputStream().write(requestBody.getBytes("UTF-8"));
+    } catch(Exception ex) {
+      println('Error sending request to endpoint: ' + ex);
+    }
+
     def postRC = post.getResponseCode();
     // println(postRC);
     if(postRC.equals(200)) {

--- a/vars/notifyPipelineStart.groovy
+++ b/vars/notifyPipelineStart.groovy
@@ -1,6 +1,4 @@
 import groovy.json.JsonOutput
-import java.net.HttpURLConnection;
-import java.net.URL;
 
 def call(params) {
 

--- a/vars/notifyPipelineStart.groovy
+++ b/vars/notifyPipelineStart.groovy
@@ -21,9 +21,7 @@ def call(params) {
     request.stageNames = getStageNames(pipeline)
 
     def requestBody = JsonOutput.toJson(request)
-    GroovyShell shell = new GroovyShell()
-    def req = shell.parse(new File('sendRequest.groovy'))
-    req.sendRequest(requestBody)
+    sendRequest(requestBody)
 }
 
 def getStageNames(pipeline){

--- a/vars/notifyPipelineStart.groovy
+++ b/vars/notifyPipelineStart.groovy
@@ -25,18 +25,16 @@ def call(params) {
     def requestBody = JsonOutput.toJson(request)
     def url = 'http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status';
 
-    // def response = httpRequest acceptType: 'APPLICATION_JSON', contentType: 'APPLICATION_JSON', httpMode: 'POST', requestBody: requestBody, url: url
-
     def post = new URL('http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status').openConnection();
     post.setRequestMethod('POST');
     post.setDoOutput(true);
-    // post.setConnectTimeout(5000);
+    post.setConnectTimeout(5000);
     post.setReadTimeout(5000);
     println('Read timeout: ' + post.getReadTimeout() + ', connect timeout: ' + post.getConnectTimeout());
     post.setRequestProperty("Content-Type", "application/json");
     post.getOutputStream().write(requestBody.getBytes("UTF-8"));
     def postRC = post.getResponseCode();
-    println(postRC);
+    // println(postRC);
     if(postRC.equals(200)) {
         println('Response: (' + postRC + ') ' + post.getInputStream().getText());
     }

--- a/vars/notifyPipelineStart.groovy
+++ b/vars/notifyPipelineStart.groovy
@@ -35,14 +35,13 @@ def call(params) {
 
     try {
       post.getOutputStream().write(requestBody.getBytes("UTF-8"));
+      def postRC = post.getResponseCode();
+      // println(postRC);
+      if(postRC.equals(200)) {
+          println('Response: (' + postRC + ') ' + post.getInputStream().getText());
+      }
     } catch(Exception ex) {
       println('Error sending request to endpoint: ' + ex);
-    }
-
-    def postRC = post.getResponseCode();
-    // println(postRC);
-    if(postRC.equals(200)) {
-        println('Response: (' + postRC + ') ' + post.getInputStream().getText());
     }
 }
 

--- a/vars/notifyPipelineStart.groovy
+++ b/vars/notifyPipelineStart.groovy
@@ -21,9 +21,7 @@ def call(params) {
     request.stageNames = getStageNames(pipeline)
 
     def requestBody = JsonOutput.toJson(request)
-    println('before requestBody here...');
     sendRequest(requestBody)
-    println('after requestBody here...');
 }
 
 def getStageNames(pipeline){

--- a/vars/notifyStageEnd.groovy
+++ b/vars/notifyStageEnd.groovy
@@ -19,6 +19,20 @@ def call(params) {
   def requestBody = JsonOutput.toJson(request)
   def url = 'http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status';
 
-  def response = httpRequest acceptType: 'APPLICATION_JSON', contentType: 'APPLICATION_JSON', httpMode: 'POST', requestBody: requestBody, url: url
-  println('Response: (' + response.status + ') ' + response.content)
+  def post = new URL('http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status').openConnection();
+    post.setRequestMethod('POST');
+    post.setDoOutput(true);
+    post.setConnectTimeout(5000);
+    post.setReadTimeout(5000);
+    post.setRequestProperty("Content-Type", "application/json");
+
+    try {
+      post.getOutputStream().write(requestBody.getBytes("UTF-8"));
+      def postRC = post.getResponseCode();
+      if(postRC.equals(200)) {
+          println('Response: (' + postRC + ') ' + post.getInputStream().getText());
+      }
+    } catch(Exception ex) {
+      println('Error sending request to endpoint: ' + ex);
+    }
 }

--- a/vars/notifyStageEnd.groovy
+++ b/vars/notifyStageEnd.groovy
@@ -17,22 +17,7 @@ def call(params) {
   request.status = params.status ? params.status : ''
 
   def requestBody = JsonOutput.toJson(request)
-  def url = 'http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status';
-
-  def post = new URL('http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status').openConnection();
-    post.setRequestMethod('POST');
-    post.setDoOutput(true);
-    post.setConnectTimeout(5000);
-    post.setReadTimeout(5000);
-    post.setRequestProperty("Content-Type", "application/json");
-
-    try {
-      post.getOutputStream().write(requestBody.getBytes("UTF-8"));
-      def postRC = post.getResponseCode();
-      if(postRC.equals(200)) {
-          println('Response: (' + postRC + ') ' + post.getInputStream().getText());
-      }
-    } catch(Exception ex) {
-      println('Error sending request to endpoint: ' + ex);
-    }
+  GroovyShell shell = new GroovyShell()
+  def req = shell.parse(new File('sendRequest.groovy'))
+  req.sendRequest(requestBody)
 }

--- a/vars/notifyStageEnd.groovy
+++ b/vars/notifyStageEnd.groovy
@@ -17,7 +17,5 @@ def call(params) {
   request.status = params.status ? params.status : ''
 
   def requestBody = JsonOutput.toJson(request)
-  GroovyShell shell = new GroovyShell()
-  def req = shell.parse(new File('sendRequest.groovy'))
-  req.sendRequest(requestBody)
+  sendRequest(requestBody)
 }

--- a/vars/notifyStageStart.groovy
+++ b/vars/notifyStageStart.groovy
@@ -16,22 +16,7 @@ def call(params) {
   request.result = 'inProgress'
 
   def requestBody = JsonOutput.toJson(request)
-  def url = 'http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status';
-
-  def post = new URL('http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status').openConnection();
-    post.setRequestMethod('POST');
-    post.setDoOutput(true);
-    post.setConnectTimeout(5000);
-    post.setReadTimeout(5000);
-    post.setRequestProperty("Content-Type", "application/json");
-
-    try {
-      post.getOutputStream().write(requestBody.getBytes("UTF-8"));
-      def postRC = post.getResponseCode();
-      if(postRC.equals(200)) {
-          println('Response: (' + postRC + ') ' + post.getInputStream().getText());
-      }
-    } catch(Exception ex) {
-      println('Error sending request to endpoint: ' + ex);
-    }
+  GroovyShell shell = new GroovyShell()
+  def req = shell.parse(new File('sendRequest.groovy'))
+  req.sendRequest(requestBody)
 }

--- a/vars/notifyStageStart.groovy
+++ b/vars/notifyStageStart.groovy
@@ -16,7 +16,5 @@ def call(params) {
   request.result = 'inProgress'
 
   def requestBody = JsonOutput.toJson(request)
-  GroovyShell shell = new GroovyShell()
-  def req = shell.parse(new File('sendRequest.groovy'))
-  req.sendRequest(requestBody)
+  sendRequest(requestBody)
 }

--- a/vars/notifyStageStart.groovy
+++ b/vars/notifyStageStart.groovy
@@ -18,6 +18,20 @@ def call(params) {
   def requestBody = JsonOutput.toJson(request)
   def url = 'http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status';
 
-  def response = httpRequest acceptType: 'APPLICATION_JSON', contentType: 'APPLICATION_JSON', httpMode: 'POST', requestBody: requestBody, url: url
-  println('Response: (' + response.status + ') ' + response.content)
+  def post = new URL('http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status').openConnection();
+    post.setRequestMethod('POST');
+    post.setDoOutput(true);
+    post.setConnectTimeout(5000);
+    post.setReadTimeout(5000);
+    post.setRequestProperty("Content-Type", "application/json");
+
+    try {
+      post.getOutputStream().write(requestBody.getBytes("UTF-8"));
+      def postRC = post.getResponseCode();
+      if(postRC.equals(200)) {
+          println('Response: (' + postRC + ') ' + post.getInputStream().getText());
+      }
+    } catch(Exception ex) {
+      println('Error sending request to endpoint: ' + ex);
+    }
 }

--- a/vars/sendRequest.groovy
+++ b/vars/sendRequest.groovy
@@ -1,5 +1,4 @@
 def call(requestBody) {
-    println('inside requestBody here...');
     def url = 'http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status';
 
     def post = new URL('http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status').openConnection();

--- a/vars/sendRequest.groovy
+++ b/vars/sendRequest.groovy
@@ -1,4 +1,5 @@
 def call(requestBody) {
+    println('inside requestBody here...');
     def url = 'http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status';
 
     def post = new URL('http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status').openConnection();

--- a/vars/sendRequest.groovy
+++ b/vars/sendRequest.groovy
@@ -17,5 +17,4 @@ def sendRequest(requestBody) {
     } catch(Exception ex) {
       println('Error sending request to endpoint: ' + ex);
     }
-
 }

--- a/vars/sendRequest.groovy
+++ b/vars/sendRequest.groovy
@@ -1,4 +1,4 @@
-def sendRequest(requestBody) {
+def call(requestBody) {
     def url = 'http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status';
 
     def post = new URL('http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status').openConnection();

--- a/vars/sendRequest.groovy
+++ b/vars/sendRequest.groovy
@@ -1,0 +1,21 @@
+def sendRequest(requestBody) {
+    def url = 'http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status';
+
+    def post = new URL('http://operator-jenkins.' + env.toolchainNamespace + '.svc.cluster.local:3000/pipeline-status').openConnection();
+    post.setRequestMethod('POST');
+    post.setDoOutput(true);
+    post.setConnectTimeout(5000);
+    post.setReadTimeout(5000);
+    post.setRequestProperty("Content-Type", "application/json");
+
+    try {
+      post.getOutputStream().write(requestBody.getBytes("UTF-8"));
+      def postRC = post.getResponseCode();
+      if(postRC.equals(200)) {
+          println('Response: (' + postRC + ') ' + post.getInputStream().getText());
+      }
+    } catch(Exception ex) {
+      println('Error sending request to endpoint: ' + ex);
+    }
+
+}


### PR DESCRIPTION
- changes the default timeout from 60 to 5 seconds
- build does not fail in event of errors of timeout, and instead simply logs the error to the build logs
- post requests are sent but are captured and ignored in a try-catch
- instead of utilizing httpListener, I decided to use the java URL class (https://docs.oracle.com/javase/7/docs/api/java/net/URL.html) as httpListener seemed to not support changing the timeout.